### PR TITLE
Implement Copy Installation Package Command for Script & Interactive 

### DIFF
--- a/front-end/src/app/components/install-package/install-package.component.html
+++ b/front-end/src/app/components/install-package/install-package.component.html
@@ -195,6 +195,13 @@
                 class="btn btn-default-sm btn-sm">
                 Install
               </button>
+              <button
+                class="mt-2"
+                type="button"
+                (click)="copy(package.id)"
+                class="btn btn-default-sm btn-sm">
+                Copy
+              </button>
             </td>
           </tr>
 

--- a/front-end/src/app/components/install-package/install-package.component.ts
+++ b/front-end/src/app/components/install-package/install-package.component.ts
@@ -177,6 +177,17 @@ export class InstallPackageComponent implements AfterViewInit {
     }
   }
 
+  copy(packageName: string) {
+    this.loading.startLoading();
+    const selectedVersion = this.packageListVersion[packageName];
+    this.commandSrv
+        .copyPackage(packageName, selectedVersion)
+        .subscribe(res => {
+          this.commandSrv.syncViews('getData');
+          this.loading.stopLoading();
+        });
+  }
+
   findPackageStableVersion(
     searchPackageResultVersions: SearchPackageResultVersion[]
   ): string {

--- a/front-end/src/app/services/command-service/command.service.ts
+++ b/front-end/src/app/services/command-service/command.service.ts
@@ -88,6 +88,23 @@ export class CommandService {
     return obs;
   }
 
+  copyPackage(
+    packageName: string,
+    selectedVersion: string
+  ): Observable<CommandResult<any>> {
+    var obs = new Observable<CommandResult<any>>(sub => {
+      command(
+        'nugetpackagemanagergui.copyPackage',
+        {
+          packageName: packageName,
+          selectedVersion: selectedVersion,
+        },
+        (res: CommandResult<any>) => sub.next(res)
+      );
+    });
+    return obs;
+  }
+
   updatePackage(
     projectId: number,
     packageName: string,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import {
 } from './services/update.service';
 import { remove, removeAllPackage } from './services/uninstall.service';
 import { install } from './services/install.service';
+import { copy } from './services/copy.service';
 
 export function activate(context: vscode.ExtensionContext) {
   const vscexpress = new VSCExpress(context, 'front-end');
@@ -183,6 +184,26 @@ export function activate(context: vscode.ExtensionContext) {
               configOptions
             ),
           undefined,
+          false
+        );
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'nugetpackagemanagergui.copyPackage',
+      async (data: {
+        packageName: string;
+        selectedVersion: string;
+      }) => {
+        await tryCatch(
+          async () =>
+            copy(
+              data.packageName,
+              data.selectedVersion
+            ),
+          `${data.packageName} copied to clipboard`,
           false
         );
       }

--- a/src/services/copy.service.ts
+++ b/src/services/copy.service.ts
@@ -1,0 +1,24 @@
+import * as vscode from 'vscode';
+import { ServiceResult } from '../models/common.model';
+
+/**
+ * Copy the package reference to the clipboard
+ * @param packageName The package name
+ * @param selectedVersion The target version
+ * @returns
+ */
+export async function copy(
+  packageName: string,
+  selectedVersion: string
+): Promise<ServiceResult> {
+
+  const packageReference = `#r "nuget:${packageName}, ${selectedVersion}"`;
+
+  await vscode.env.clipboard.writeText(packageReference);
+
+  return {
+    isSuccessful: true,
+    message: `The package '${packageName}' has been copied to the clipboard.`,
+  };
+
+}


### PR DESCRIPTION

Summary:
This pull request introduces a new feature to the NuGet Package Manager GUI that allows users to copy a NuGet package installation command for script directly to the clipboard.   
This is achieved by adding a new "Copy" button in the package installation interface and implementing the corresponding backend service to handle the copy   
action. The feature enhances the user experience by providing a quick and easy way to copy package references for use in other applications or documents.    

Changes:
1. **Front-end Changes:**
   - Modified `install-package.component.html` to include a new "Copy" button next to the "Install" button for each package listed in the GUI.
   - Updated `install-package.component.ts` by adding a new `copy` method that triggers the loading animation, calls the `copyPackage` service with the      
selected package name and version, and then stops the loading animation once the operation is complete.

2. **Service Layer Updates:**
   - Updated `command.service.ts` to include a new `copyPackage` method that creates an observable to send the `nugetpackagemanagergui.copyPackage` command  
along with the package name and selected version to the backend.

3. **Extension Backend Enhancements:**
   - Modified `extension.ts` to register a new command `nugetpackagemanagergui.copyPackage` that calls the `copy` function from the newly created
`copy.service.ts`.
   - Added a new file `copy.service.ts` that contains the `copy` function. This function constructs the package reference string and uses the Visual Studio  
Code API to write it to the system clipboard.